### PR TITLE
fix: ugly JSON response's structure

### DIFF
--- a/internal/api/v1/shorten/list_test.go
+++ b/internal/api/v1/shorten/list_test.go
@@ -25,15 +25,15 @@ func TestListShorten(t *testing.T) {
 			Url:       "go",
 			Target:    "https://go.dev",
 			Permanent: true,
-			CreatedAt: sql.NullTime{Time: time.Now(), Valid: true},
-			UpdatedAt: sql.NullTime{Time: time.Now(), Valid: true},
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
 		},
 		database.Shorten{
 			ID:        2,
 			Url:       "dart",
 			Target:    "https://pub.dev",
-			CreatedAt: sql.NullTime{Time: time.Now(), Valid: true},
-			UpdatedAt: sql.NullTime{Time: time.Now(), Valid: true},
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
 		},
 	}
 
@@ -63,8 +63,8 @@ func TestListShorten(t *testing.T) {
 					assert.Equal(t, s.Url, ss.Url)
 					assert.Equal(t, s.Target, ss.Target)
 					assert.Equal(t, s.Permanent, ss.Permanent)
-					assert.WithinDuration(t, s.CreatedAt.Time, ss.CreatedAt.Time, 0)
-					assert.WithinDuration(t, s.UpdatedAt.Time, ss.UpdatedAt.Time, 0)
+					assert.WithinDuration(t, s.CreatedAt, ss.CreatedAt, 0)
+					assert.WithinDuration(t, s.UpdatedAt, ss.UpdatedAt, 0)
 				}
 			}
 		}

--- a/internal/api/v1/shorten/update_test.go
+++ b/internal/api/v1/shorten/update_test.go
@@ -18,14 +18,13 @@ import (
 )
 
 func TestUpdateShorten(t *testing.T) {
-	sqlNullTime := sql.NullTime{Time: time.Now(), Valid: true}
 	shortenInDatabase := database.Shorten{
 		ID:        11,
 		Url:       "go",
 		Target:    "https://pub.dev",
 		Permanent: false,
-		UpdatedAt: sqlNullTime,
-		CreatedAt: sqlNullTime,
+		UpdatedAt: time.Now(),
+		CreatedAt: time.Now(),
 	}
 	newShorten := database.UpdateShortenParams{
 		ID:        11,

--- a/internal/database/migration/000001_create_table_send_shorten.up.sql
+++ b/internal/database/migration/000001_create_table_send_shorten.up.sql
@@ -5,8 +5,8 @@ CREATE TABLE "shorten" (
   "url" varchar NOT NULL,
   "target" varchar NOT NULL,
   "permanent" boolean DEFAULT false NOT NULL,
-  "created_at" timestamptz DEFAULT (now()),
-  "updated_at" timestamptz DEFAULT (now())
+  "created_at" timestamptz DEFAULT (now()) NOT NULL,
+  "updated_at" timestamptz DEFAULT (now()) NOT NULL
 );
 
 CREATE TABLE "send" (
@@ -15,8 +15,8 @@ CREATE TABLE "send" (
   "file" varchar NOT NULL,
   "size" varchar NOT NULL,
   "permanent" boolean DEFAULT false NOT NULL,
-  "created_at" timestamptz DEFAULT (now()),
-  "updated_at" timestamptz DEFAULT (now())
+  "created_at" timestamptz DEFAULT (now()) NOT NULL,
+  "updated_at" timestamptz DEFAULT (now()) NOT NULL
 );
 
 COMMIT;

--- a/internal/database/sql/models.go
+++ b/internal/database/sql/models.go
@@ -5,24 +5,24 @@
 package database
 
 import (
-	"database/sql"
+	"time"
 )
 
 type Send struct {
-	ID        int64        `json:"id"`
-	Url       string       `json:"url"`
-	File      string       `json:"file"`
-	Size      string       `json:"size"`
-	Permanent bool         `json:"permanent"`
-	CreatedAt sql.NullTime `json:"created_at"`
-	UpdatedAt sql.NullTime `json:"updated_at"`
+	ID        int64     `json:"id"`
+	Url       string    `json:"url"`
+	File      string    `json:"file"`
+	Size      string    `json:"size"`
+	Permanent bool      `json:"permanent"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 type Shorten struct {
-	ID        int64        `json:"id"`
-	Url       string       `json:"url"`
-	Target    string       `json:"target"`
-	Permanent bool         `json:"permanent"`
-	CreatedAt sql.NullTime `json:"created_at"`
-	UpdatedAt sql.NullTime `json:"updated_at"`
+	ID        int64     `json:"id"`
+	Url       string    `json:"url"`
+	Target    string    `json:"target"`
+	Permanent bool      `json:"permanent"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }

--- a/internal/database/sql/shorten_test.go
+++ b/internal/database/sql/shorten_test.go
@@ -134,8 +134,8 @@ func TestQueries_GetShortenByUrl(t *testing.T) {
 				assert.Equal(t, listOfShortenInstances[0].Url, sh.Url)
 				assert.Equal(t, listOfShortenInstances[0].Target, sh.Target)
 				assert.Equal(t, listOfShortenInstances[0].Permanent, sh.Permanent)
-				assert.WithinDuration(t, listOfShortenInstances[0].CreatedAt.Time, sh.CreatedAt.Time, 0)
-				assert.WithinDuration(t, listOfShortenInstances[0].UpdatedAt.Time, sh.UpdatedAt.Time, 0)
+				assert.WithinDuration(t, listOfShortenInstances[0].CreatedAt, sh.CreatedAt, 0)
+				assert.WithinDuration(t, listOfShortenInstances[0].UpdatedAt, sh.UpdatedAt, 0)
 			case true:
 				require.Error(t, err)
 				assert.Empty(t, sh, "Not found data should be empty")


### PR DESCRIPTION
should use `time.Time` instead of `sql.NullTime` for both `created_at` & `updated_at` fields