### PR TITLE
fix(ci): error caused by deprecated param in goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,6 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release -f .goreleaser.yml --rm-dist
+          args: release -f .goreleaser.yml --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- fix deprecated param `--rm-dist` in goreleaser. [docs](https://goreleaser.com/deprecations/#-rm-dist)